### PR TITLE
Fix download function, add CLI arg for stats vs full download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 swift_config.ini
 downloads
+.venv/

--- a/100g-anon_download-objects.py
+++ b/100g-anon_download-objects.py
@@ -1,8 +1,8 @@
-#+
+# +
 # NAME:
 #   100g-anon_download-objects.py
 # PURPOSE:
-#   Downloads anonymized pcap files for a given timestamp 
+#   Downloads anonymized pcap files for a given timestamp
 # INPUTS:
 #   [Required] {timestamp} - yyyymmdd-hhmmss
 #     e.g. 20240418-181500
@@ -21,7 +21,7 @@
 #   2) [IMPORTANT] `swift_config.ini` is configured with the following credentials
 #        aws_access_key_id
 #        aws_secret_access_key
-#-
+# -
 
 import re
 import os
@@ -40,27 +40,32 @@ config = configparser.ConfigParser()
 config.read(SWIFT_CONFIG)
 access_config = config["100g_s3_access"]
 
-parser = argparse.ArgumentParser(description='Download files for a given capture')
-parser.add_argument('-ts', '--timestamp', dest='timestamp', help='Specify which capture to download')
-parser.add_argument('-b', '--bucket', dest='bucket', help='Specify which bucket to download from')
+parser = argparse.ArgumentParser(
+    description='Download files for a given capture')
+parser.add_argument('-ts', '--timestamp', dest='timestamp',
+                    help='Specify which capture to download')
+parser.add_argument('-b', '--bucket', dest='bucket',
+                    help='Specify which bucket to download from')
 args = parser.parse_args()
+
 
 def config_client() -> object:
     """
     Configures the s3 client
     """
-    #boto3.set_stream_logger(name='botocore')  # this enables debug tracing
+    # boto3.set_stream_logger(name='botocore')  # this enables debug tracing
     session = boto3.Session()
     s3_client = session.client(
         service_name='s3',
-        endpoint_url = access_config["endpoint_url"],
-        aws_access_key_id = access_config["aws_access_key_id"],
-        aws_secret_access_key = access_config["aws_secret_access_key"],
+        endpoint_url=access_config["endpoint_url"],
+        aws_access_key_id=access_config["aws_access_key_id"],
+        aws_secret_access_key=access_config["aws_secret_access_key"],
         config=botocore.client.Config(signature_version='s3v4'),
     )
     return s3_client
 
-def download(bucket:str, s3_client:object, key:str, filename:str) -> None:
+
+def download(bucket: str, s3_client: object, key: str, filename: str) -> None:
     """
     Retrieves files from swift bucket/container
     """
@@ -73,6 +78,7 @@ def download(bucket:str, s3_client:object, key:str, filename:str) -> None:
         print(f"{error}")
         print("-"*50)
 
+
 def download_files() -> None:
     """
     Downloads the files associated with the specified timestamp
@@ -82,7 +88,7 @@ def download_files() -> None:
     year = (args.timestamp).split("-")[0][:4]
     month = (args.timestamp).split("-")[0][4:6]
 
-    file_prefix = f"monitor=100g-01/mon={month}/date={args.timestamp}.UTC"
+    file_prefix = f"monitor=100g-01/year={year}/mon={month}/date={args.timestamp}.UTC"
 
     # Have to create directories in order to download files
     file_path = f"downloads/{file_prefix}"
@@ -90,29 +96,31 @@ def download_files() -> None:
     Path(file_path).mkdir(parents=True, exist_ok=True)
 
     for direction in ["a", "b"]:
-        for file_suffix in ["stats"]: # ["stats", "anon.pcap.gz"]:
+        for file_suffix in ["stats"]:  # ["stats", "anon.pcap.gz"]:
             key = f"{file_prefix}/{args.timestamp}.dir{direction}.{file_suffix}"
             filename = f'{HOME}/downloads/{key}'
             download(args.bucket, s3_client, key, filename)
 
     # For downloading from multiple buckets
-    #for bucket in (access_config["buckets"]).split():
+    # for bucket in (access_config["buckets"]).split():
     #    for direction in ["a", "b"]:
     #        for file_suffix in ["stats"]: # ["stats", "anon.pcap.gz"]:
     #            key = f"{file_prefix}/{args.timestamp}.dir{direction}.{file_suffix}"
     #            filename = f'{HOME}/downloads/{key}'
     #            download(access_config["bucket"], s3_client, key, filename)
 
+
 def main():
     # Validates Input
-    ts_pattern = re.compile('\d{8}-\d{6}') # e.g. 20240418-181500
+    ts_pattern = re.compile('\d{8}-\d{6}')  # e.g. 20240418-181500
 
     if not (args.timestamp):
         print("Timestamp is required --> -ts YYYYMMDD-HHMMSS")
         sys.exit()
 
     if not (ts_pattern.match(str(args.timestamp))):
-        print(f"Incorrect timestamp format: {args.timestamp} --> YYYYMMDD-HHMMSS")
+        print(
+            f"Incorrect timestamp format: {args.timestamp} --> YYYYMMDD-HHMMSS")
         sys.exit()
 
     if not (args.bucket):
@@ -120,6 +128,7 @@ def main():
         sys.exit()
 
     download_files()
+
 
 if __name__ == "__main__":
     main()

--- a/100g-anon_download-objects.py
+++ b/100g-anon_download-objects.py
@@ -9,11 +9,16 @@
 #
 #   [Required] {bucket} - 100g-anon-pcap-{year}
 #     e.g. 100g-anon-pcap-2024
+#
+#   [Optional] {stats_only} - By default, only download stats files. Use the `-f / --full` flag to download both stats and pcap files.
+#     -s / --stats-only : Download only stats files (default: True)
+#     -f / --full       : Download stats and anon.pcap.gz files
 # OUTPUTS:
-#   ./downloads/monitor=100g-01/mon={MM}/date={timestamp}.UTC/{file}
+#   ./downloads/monitor=100g-01/year={YYYY}/mon={MM}/date={timestamp}.UTC/{file}
 # EXAMPLES:
 #   python3 100g-anon_download-objects.py -ts {timestamp} -b {bucket}
 #   python3 100g-anon_download-objects.py -ts 20240418-181500 -b 100g-anon-pcap-2024
+#   python3 100g-anon_download-objects.py -ts 20240418-181500 -b 100g-anon-pcap-2024 --full
 # ASSUMPTIONS:
 #   1) [IMPORTANT] Assumes that one has at least 3TB of disk space to store
 #      the two pcap files (one for each direction).
@@ -42,6 +47,11 @@ access_config = config["100g_s3_access"]
 
 parser = argparse.ArgumentParser(
     description='Download files for a given capture')
+parser.add_argument('-s', '--stats-only', dest='stats_only', action='store_true',
+                    help='Download only stats files (default)')
+parser.add_argument('-f', '--full', dest='stats_only', action='store_false',
+                    help='Download full pcap and stats files')
+parser.set_defaults(stats_only=True)
 parser.add_argument('-ts', '--timestamp', dest='timestamp',
                     help='Specify which capture to download')
 parser.add_argument('-b', '--bucket', dest='bucket',
@@ -95,8 +105,9 @@ def download_files() -> None:
     print(f"Creating directory path: {file_path}")
     Path(file_path).mkdir(parents=True, exist_ok=True)
 
+    file_suffixes = ["stats"] if args.stats_only else ["stats", "anon.pcap.gz"]
     for direction in ["a", "b"]:
-        for file_suffix in ["stats"]:  # ["stats", "anon.pcap.gz"]:
+        for file_suffix in file_suffixes:
             key = f"{file_prefix}/{args.timestamp}.dir{direction}.{file_suffix}"
             filename = f'{HOME}/downloads/{key}'
             download(args.bucket, s3_client, key, filename)

--- a/100g-anon_list-objects.py
+++ b/100g-anon_list-objects.py
@@ -1,8 +1,8 @@
-#+
+# +
 # NAME:
 #   100g-anon_list-objects.py
 # PURPOSE:
-#   List the files in the 100g-anon-pcap bucket/container 
+#   List the files in the 100g-anon-pcap bucket/container
 # INPUTS:
 #   [Optional] {timestamp flag}: -ts
 #   [Optional] {bucket flag}: -b
@@ -29,7 +29,7 @@
 #        buckets
 #        aws_access_key_id
 #        aws_secret_access_key
-#-
+# -
 
 import os
 import json
@@ -47,19 +47,23 @@ config = configparser.ConfigParser()
 config.read(SWIFT_CONFIG)
 access_config = config["100g_s3_access"]
 
-parser = argparse.ArgumentParser(description='List files in 100g-anon-pcap Container')
-parser.add_argument('-ts', '--timestamps', dest='timestamps', action='store_true', default=False, help='List unique timestamps of objects')
-parser.add_argument('-ab', '--allbuckets', dest='buckets', action='store_true', default=True, help='List objects from all buckets (Default)')
-parser.add_argument('-b', '--bucket', dest='bucket', help='List objects from one bucket')
+parser = argparse.ArgumentParser(
+    description='List files in 100g-anon-pcap Container')
+parser.add_argument('-ts', '--timestamps', dest='timestamps', action='store_true',
+                    default=False, help='List unique timestamps of objects')
+parser.add_argument('-ab', '--allbuckets', dest='buckets', action='store_true',
+                    default=True, help='List objects from all buckets (Default)')
+parser.add_argument('-b', '--bucket', dest='bucket',
+                    help='List objects from one bucket')
 args = parser.parse_args()
 
-#boto3.set_stream_logger(name='botocore')  # this enables debug tracing
+# boto3.set_stream_logger(name='botocore')  # this enables debug tracing
 session = boto3.Session()
 s3_client = session.client(
-    service_name = 's3',
-    endpoint_url = access_config["endpoint_url"],
-    aws_access_key_id = access_config["aws_access_key_id"],
-    aws_secret_access_key = access_config["aws_secret_access_key"],
+    service_name='s3',
+    endpoint_url=access_config["endpoint_url"],
+    aws_access_key_id=access_config["aws_access_key_id"],
+    aws_secret_access_key=access_config["aws_secret_access_key"],
     config=botocore.client.Config(signature_version='s3')
 )
 

--- a/README.md
+++ b/README.md
@@ -1,36 +1,58 @@
 # 100g-passive-tools
+
 This repository contains code recipes to demonstrate how to access CAIDA's 100G passive pcap data using various methods.
 
+## Requirements
+
+- Python <= 3.13 (tested on 3.11, incompatible with 3.13+)
+  - boto3==1.23.10
+  - botocore==1.26.10
+  - configparser==3.5.3
+
 ---
+
 Clone the repository into an environment that has a minimum of **2TB of disk space**
-```
+
+```bash
 git clone https://github.com/CAIDA/100g-passive-tools.git
 ```
 
+(Recommended) Create a virtual environment
+
+```bash
+python -m venv .venv
+```
+
 ### Configuration
+
 ---
+
 In order to access CAIDA's swift server, a `swift_config.ini` file will have to be configured in the repository directory, using the AWS S3 credentials provided in the confirmation email (`aws_access_key_id` and `aws_secret_access_key`).<br/><br/>
 **Note:** One can use the following config file template to get started: [swift_config-example.ini](https://github.com/CAIDA/100g-passive-tools/blob/main/swift_config-example.ini)
 
 ### Considerations
 
 ---
+
 Each one-directional anonymized pcap file, captured monthly, can reach up to approximately **1TB in size**, so users will need more than **2TB of space** to download the entire one-hour capture.
 
 ### Troubleshooting
 
 ---
+
 Refer to the following [Wiki Page](https://github.com/CAIDA/100g-passive-tools/wiki/Troubleshooting) to troubleshoot commonly found errors.
 
 <br/>
 
 # Access Methods
+
 **Note:** Refer to the [requirements.txt](https://github.com/CAIDA/100g-passive-tools/blob/main/requirements.txt) file to install the dependencies needed for the recipes.
 <br/><br/>
 
 ### AWS SDK (boto3)
 
 ---
+
 **Note:** This method requires a `swift_config.ini` file to be configured, and assumes you've installed [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) locally.
 
 Refer to the following recipes to download or list out files for a given capture, [100g-anon_download-objects.py](https://github.com/CAIDA/100g-passive-tools/blob/main/100g-anon_download-objects.py) and [100g-anon_list-objects.py](https://github.com/CAIDA/100g-passive-tools/blob/main/100g-anon_list-objects.py)
@@ -40,21 +62,26 @@ Refer to the following recipes to download or list out files for a given capture
 ### AWS CLI
 
 ---
+
 **Note:** This method requires your `~/.aws/credentials` file to be configured, and assumes you've set up [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html) locally.<br/>
 For installing instructions, reference [AWS Documentation](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
-```
+
+```ini
 [default]
-aws_access_key_id = 
-aws_secret_access_key = 
+aws_access_key_id =
+aws_secret_access_key =
 ```
 
 **List out files in the 100g-anon-pcap bucket/container**<br/>
-```
+
+```bash
 aws s3api list-objects --bucket 100g-anon-pcap-{year} --endpoint-url https://hermes.caida.org --output text
 ```
+
 **Note:** `--output {text|json|table}`
 
 **Download a file in the 100g-anon-pcap-{year} bucket/container**<br/>
-```
+
+```bash
 aws s3api get-object --bucket 100g-anon-pcap-{year} --key monitor=100g-01/mon=05/date=20240523-210000.UTC/20240523-210000.dira.stats --endpoint-url https://hermes.caida.org --output text 20240523-210000.dira.stats
 ```


### PR DESCRIPTION
Two main changes:
  - Fixed `file_prefix` to include the year for container IDs
  - Added CLI args for downloading just the stats or both stats and the full pcap files
    - The default option was to download stats only, and users had to navigate to line 91 to make manual edits in order to download full DS files.

Other changes: 
  - formatting: sorry, blame autopep8 or the original author -- as long as you don't blame me
  - README updated to include recommendations, notably python version -- must be < 3.13 due to `cgi` module being removed from Python standard library